### PR TITLE
showing/hiding series bar rect on y axis not configurable via property 

### DIFF
--- a/px-vis-xy-chart.html
+++ b/px-vis-xy-chart.html
@@ -199,6 +199,7 @@ A chart which allows line drawing or scatter on arbitrary X and Y axis
         margin="[[margin]]"
         orientation="left"
         complete-series-config="[[completeSeriesConfig]]"
+        prevent-series-bar
         domain-changed="[[domainChanged]]"
         current-domain="[[currentDomainY]]"
         muted-series="[[mutedSeries]]"

--- a/px-vis-xy-chart.html
+++ b/px-vis-xy-chart.html
@@ -182,7 +182,7 @@ A chart which allows line drawing or scatter on arbitrary X and Y axis
         margin="[[margin]]"
         orientation="bottom"
         complete-series-config="[[completeSeriesConfig]]"
-        prevent-series-bar
+        prevent-series-bar="[[preventSeriesBarOnXAxis]]"
         domain-changed="[[domainChanged]]"
         current-domain="[[currentDomainX]]"
         muted-series="[[mutedSeries]]"
@@ -199,7 +199,7 @@ A chart which allows line drawing or scatter on arbitrary X and Y axis
         margin="[[margin]]"
         orientation="left"
         complete-series-config="[[completeSeriesConfig]]"
-        prevent-series-bar
+        prevent-series-bar="[[preventSeriesBarOnYAxis]]"
         domain-changed="[[domainChanged]]"
         current-domain="[[currentDomainY]]"
         muted-series="[[mutedSeries]]"
@@ -308,6 +308,14 @@ A chart which allows line drawing or scatter on arbitrary X and Y axis
       PxVisBehavior.toolbarConfig
     ],
     properties: {
+      preventSeriesBarOnXAxis: {
+        type: Boolean,
+        value: true
+      },
+      preventSeriesBarOnYAxis: {
+        type: Boolean,
+        value: false
+      },
       /**
        * Configuration object used to customize the X axis cosmetic properties.
        * Please refer to px-vis-axis (https://github.com/PredixDev/px-vis) for a list of supported proerties

--- a/px-vis-xy-chart.html
+++ b/px-vis-xy-chart.html
@@ -182,7 +182,7 @@ A chart which allows line drawing or scatter on arbitrary X and Y axis
         margin="[[margin]]"
         orientation="bottom"
         complete-series-config="[[completeSeriesConfig]]"
-        prevent-series-bar="[[preventSeriesBarOnXAxis]]"
+        prevent-series-bar="[[preventSeriesBarOnXaxis]]"
         domain-changed="[[domainChanged]]"
         current-domain="[[currentDomainX]]"
         muted-series="[[mutedSeries]]"
@@ -199,7 +199,7 @@ A chart which allows line drawing or scatter on arbitrary X and Y axis
         margin="[[margin]]"
         orientation="left"
         complete-series-config="[[completeSeriesConfig]]"
-        prevent-series-bar="[[preventSeriesBarOnYAxis]]"
+        prevent-series-bar="[[preventSeriesBarOnYaxis]]"
         domain-changed="[[domainChanged]]"
         current-domain="[[currentDomainY]]"
         muted-series="[[mutedSeries]]"
@@ -308,12 +308,22 @@ A chart which allows line drawing or scatter on arbitrary X and Y axis
       PxVisBehavior.toolbarConfig
     ],
     properties: {
-      preventSeriesBarOnXAxis: {
-        type: Boolean,
+      /**
+       * property to bind to px-vis-axis's prevent-resize-bar
+       * visit https://www.predix-ui.com/px-vis/px-vis/#px-vis-axis-x-anchor
+       * note that this has to be Object and not Boolean
+       * visit https://github.com/Polymer/polymer/issues/1812
+       */
+      preventSeriesBarOnXaxis: {
+        type: Object,
         value: true
       },
-      preventSeriesBarOnYAxis: {
-        type: Boolean,
+      /**
+       * property to bind to px-vis-axis's prevent-resize-bar
+       * this one is for y axis
+       */
+      preventSeriesBarOnYaxis: {
+        type: Object,
         value: false
       },
       /**


### PR DESCRIPTION
Issue: showing/hiding series bar rect on y axis not configurable via property (https://github.com/PredixDev/px-vis-xy-chart/issues/11)

To entirely fix this, there are two required changes
one is px-vis-axis.html that is part of px-vis repo
Here is pull request for that change
https://github.com/PredixDev/px-vis/pull/69

second one is, here, i.e. exposing properties. In our case, we are going to have only one series, and series bar may not be necessary, hence having a config property should be good.

Hope this helps,
Sandeep Khandewale
(Consultant, GE Oil and Gas, Mumbai)